### PR TITLE
Trivial correction to 1.7 upgrade instructions

### DIFF
--- a/site/content/docs/v1.7/upgrade-to-1.7.md
+++ b/site/content/docs/v1.7/upgrade-to-1.7.md
@@ -53,7 +53,7 @@ Before upgrading, check the [Velero compatibility matrix](https://github.com/vmw
    # if you are using other plugin
     kubectl set image deployment/velero \
         velero=velero/velero:v1.7.0 \
-        velero-velero-plugin-for-aws=velero/velero-plugin-for-aws:v1.3.0 \
+        velero-plugin-for-aws=velero/velero-plugin-for-aws:v1.3.0 \
         --namespace velero
 
     # optional, if using the restic daemon set


### PR DESCRIPTION
Signed-off-by: Dave Pedu <dave@davepedu.com>

Thank you for contributing to Velero!

# Please add a summary of your change

The container name for the aws plugin is `velero-plugin-for-aws`. There was an extra `velero-` prefix in the doc.

# Does your change fix a particular issue?

N/A

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- `n/a` Updated the corresponding documentation in `site/content/docs/main`.
